### PR TITLE
refactor: fetch metadata only when getProposal

### DIFF
--- a/src/client/DAOClient.ts
+++ b/src/client/DAOClient.ts
@@ -263,7 +263,8 @@ class DAOClient implements zDAO {
           {
             strategies: this._options.strategies,
             scores_state: proposal.scores_state,
-          }
+          },
+          false
         )
     );
 

--- a/src/client/ProposalClient.ts
+++ b/src/client/ProposalClient.ts
@@ -98,7 +98,8 @@ class ProposalClient implements Proposal {
     snapshotClient: SnapshotClient,
     gnosisSafeClient: GnosisSafeClient,
     properties: ProposalProperties,
-    options: any
+    options: any,
+    requireMetadata = true
   ): Promise<Proposal> {
     const proposal = new ProposalClient(
       zDAO,
@@ -107,7 +108,9 @@ class ProposalClient implements Proposal {
       properties,
       options
     );
-    await proposal.getTokenMetadata();
+    if (requireMetadata) {
+      await proposal.getTokenMetadata();
+    }
     return proposal;
   }
 


### PR DESCRIPTION
* fetch metdata only when call `getProposal`, not `listProposals`