### PR TITLE
fix: change limit of graphql query

### DIFF
--- a/src/client/DAOClient.ts
+++ b/src/client/DAOClient.ts
@@ -292,7 +292,7 @@ class DAOClient implements zDAO {
   }
 
   async listProposals(pagination?: PaginationParam): Promise<Proposal[]> {
-    const limit = 3000;
+    const limit = 1000;
     let from = pagination?.from ?? 0;
     let count = pagination?.count ?? limit;
     let numberOfResults = limit;

--- a/src/client/ProposalClient.ts
+++ b/src/client/ProposalClient.ts
@@ -162,7 +162,7 @@ class ProposalClient implements Proposal {
   }
 
   async listVotes(pagination?: PaginationParam): Promise<Vote[]> {
-    const limit = 30000;
+    const limit = 1000;
     let from = pagination?.from ?? 0;
     let count = pagination?.count ?? limit;
     let numberOfResults = limit;

--- a/src/snapshot-io/index.ts
+++ b/src/snapshot-io/index.ts
@@ -225,7 +225,7 @@ class SnapshotClient {
     spaceId: ENS,
     network: string,
     from = 0,
-    count = 30000
+    count = 1000
   ): Promise<SnapshotProposal[]> {
     const response = await graphQLQuery(
       this.graphQLClient,


### PR DESCRIPTION
Since the snapshot backend was updated, query limit also has been changed.