### PR TITLE
safeclient listCollections

### DIFF
--- a/src/safe-global/index.ts
+++ b/src/safe-global/index.ts
@@ -77,7 +77,7 @@ class SafeGlobalClient {
 
       const res = await fetch(url);
       const data = await res.json();
-      return data;
+      return data.results;
     } catch (error: any) {
       throw new Error(
         errorMessageForError('network-error', {


### PR DESCRIPTION
Not sure what happened because I thought the URLs had changed, but this one line change was all that was needed to make the gnosis-safe unit tests work again.

There's a snapshot test that is still failing.