### PR TITLE
feat: proposal votes query configuration

### DIFF
--- a/src/client/ProposalClient.ts
+++ b/src/client/ProposalClient.ts
@@ -178,7 +178,6 @@ class ProposalClient implements Proposal {
         snapshot: Number(this.snapshot),
         from,
         count: count >= limit ? limit : count,
-        voter: '',
       });
       votes.push(
         ...results.map((vote: any) => ({

--- a/src/client/ProposalClient.ts
+++ b/src/client/ProposalClient.ts
@@ -5,7 +5,7 @@ import { cloneDeep } from 'lodash';
 
 import SafeGlobalClient from '../safe-global';
 import SnapshotClient from '../snapshot-io';
-import { ListVotesParams, SnapshotProposal } from "../snapshot-io/types";
+import { ListVotesParams, SnapshotProposal } from '../snapshot-io/types';
 import { ProposalProperties, ProposalState, VoteId } from '../types';
 import { Choice, Proposal, Vote } from '../types';
 import { getDecimalAmount } from '../utilities';

--- a/src/client/ProposalClient.ts
+++ b/src/client/ProposalClient.ts
@@ -5,13 +5,8 @@ import { cloneDeep } from 'lodash';
 
 import SafeGlobalClient from '../safe-global';
 import SnapshotClient from '../snapshot-io';
-import { SnapshotProposal } from '../snapshot-io/types';
-import {
-  PaginationParam,
-  ProposalProperties,
-  ProposalState,
-  VoteId,
-} from '../types';
+import { ListVotesParams, SnapshotProposal } from "../snapshot-io/types";
+import { ProposalProperties, ProposalState, VoteId } from '../types';
 import { Choice, Proposal, Vote } from '../types';
 import { getDecimalAmount } from '../utilities';
 import { errorMessageForError } from '../utilities/messages';
@@ -161,10 +156,12 @@ class ProposalClient implements Proposal {
     };
   }
 
-  async listVotes(pagination?: PaginationParam): Promise<Vote[]> {
+  async listVotes(
+    options?: Partial<Pick<ListVotesParams, 'from' | 'count' | 'voter'>>
+  ): Promise<Vote[]> {
     const limit = 1000;
-    let from = pagination?.from ?? 0;
-    let count = pagination?.count ?? limit;
+    let from = options?.from ?? 0;
+    let count = options?.count ?? limit;
     let numberOfResults = limit;
     const votes: Vote[] = [];
 
@@ -178,6 +175,7 @@ class ProposalClient implements Proposal {
         snapshot: Number(this.snapshot),
         from,
         count: count >= limit ? limit : count,
+        voter: options?.voter,
       });
       votes.push(
         ...results.map((vote: any) => ({

--- a/src/snapshot-io/index.ts
+++ b/src/snapshot-io/index.ts
@@ -373,7 +373,7 @@ class SnapshotClient {
       VOTES_QUERY,
       {
         id: params.proposalId,
-        orderBy: 'created',
+        orderBy: 'vp',
         orderDirection: 'desc',
         first: params.count,
         skip: params.from,

--- a/src/snapshot-io/index.ts
+++ b/src/snapshot-io/index.ts
@@ -376,7 +376,6 @@ class SnapshotClient {
         orderBy: 'vp',
         orderDirection: 'desc',
         first: params.count,
-        voter: params.voter,
         skip: params.from,
       },
       'votes'

--- a/src/snapshot-io/index.ts
+++ b/src/snapshot-io/index.ts
@@ -377,6 +377,7 @@ class SnapshotClient {
         orderDirection: 'desc',
         first: params.count,
         skip: params.from,
+        voter: params.voter,
       },
       'votes'
     );

--- a/src/snapshot-io/index.ts
+++ b/src/snapshot-io/index.ts
@@ -373,7 +373,7 @@ class SnapshotClient {
       VOTES_QUERY,
       {
         id: params.proposalId,
-        orderBy: 'vp',
+        orderBy: 'created',
         orderDirection: 'desc',
         first: params.count,
         skip: params.from,

--- a/src/snapshot-io/types.ts
+++ b/src/snapshot-io/types.ts
@@ -22,6 +22,7 @@ export interface ListVotesParams extends SpaceParams {
   snapshot: number;
   from: number;
   count: number;
+  voter?: string;
 }
 
 export interface ERC20BalanceOfParams extends SpaceParams {

--- a/src/snapshot-io/types.ts
+++ b/src/snapshot-io/types.ts
@@ -22,7 +22,6 @@ export interface ListVotesParams extends SpaceParams {
   snapshot: number;
   from: number;
   count: number;
-  voter: string;
 }
 
 export interface ERC20BalanceOfParams extends SpaceParams {

--- a/src/types/instances.ts
+++ b/src/types/instances.ts
@@ -2,7 +2,7 @@ import { Web3Provider } from '@ethersproject/providers';
 import { Wallet } from '@ethersproject/wallet';
 
 import { SafeGlobalAccountDetails } from '../safe-global/types';
-import { SnapshotSpaceDetails } from '../snapshot-io/types';
+import { ListVotesParams, SnapshotSpaceDetails } from "../snapshot-io/types";
 import { SupportedChainId } from './enumerations';
 import {
   CreateProposalParams,
@@ -143,7 +143,9 @@ export interface Proposal extends ProposalProperties {
    * Get all the votes by proposal id filtering with the function parameter
    * @returns list of votes
    */
-  listVotes(pagination?: PaginationParam): Promise<Vote[]>;
+  listVotes(
+    options?: Partial<Pick<ListVotesParams, 'from' | 'count' | 'voter'>>
+  ): Promise<Vote[]>;
 
   /**
    * Get voting power of the user in zDAO


### PR DESCRIPTION
- `listVotes` was broken, because `from` was always empty string
- Added extra parameters to `listVotes` configuration object for greater control in UI. Added option is `from`. This change isn't breaking.