### PR TITLE
feat: add values to `Proposal` graph query

### DIFF
--- a/src/snapshot-io/queries.ts
+++ b/src/snapshot-io/queries.ts
@@ -117,6 +117,8 @@ export const PROPOSAL_QUERY = gql`
       scores_by_strategy
       scores_total
       votes
+      quorum
+      link
     }
   }
 `;


### PR DESCRIPTION
Added the following fields to the `Proposal` graph query
- `quorum` (quorum of the proposal)
- `link` (link to the Snapshot page for the proposal)